### PR TITLE
Updating typescript version ( to have cjs exports __esModule = true )

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ts-node": "^2.0.0",
     "tslib": "^1.5.0",
     "tslint": "^4.3.1",
-    "typescript": "^2.1.5"
+    "typescript": "^2.2.1"
   },
   "keywords": [
     "react",

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,17 +313,13 @@ make-error@^1.1.1:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
@@ -570,9 +566,9 @@ tslint@^4.3.1:
     underscore.string "^3.3.4"
     update-notifier "^1.0.2"
 
-typescript@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.5.tgz#6fe9479e00e01855247cea216e7561bafcdbcd4a"
+typescript@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz#4862b662b988a4c8ff691cc7969622d24db76ae9"
 
 underscore.string@^3.3.4:
   version "3.3.4"


### PR DESCRIPTION
Updated Typescript generates `exports.__esModules=true` necessary for new SystemJS@ 0.20.x
http://guybedford.com/systemjs-alignment